### PR TITLE
Add support for Sublime Text 4 documentation keywords

### DIFF
--- a/prefix_methods.py
+++ b/prefix_methods.py
@@ -23,6 +23,7 @@ KEYWORD_MAP = {
     "Class": "class",
     "Value": "type",
     "Tuple": "type",
+    "Dict": "type",
 }
 
 


### PR DESCRIPTION
This PR adds support for the `Dict` type so Sublime Text 4 documents can be parsed correctly
<img width="417" alt="image" src="https://user-images.githubusercontent.com/471335/132537622-99e585e9-40bd-4a77-8a42-d2951d4734f0.png">

Fixes #13 
