### PR TITLE
Adjust color scheme symbols

### DIFF
--- a/resources/sublime-text.toml
+++ b/resources/sublime-text.toml
@@ -219,8 +219,8 @@ attr = 'id'
 type = 'Setting'
 
 [[selectors.color_schemes]]
-# Font styles
-css = 'dt#font-style dd li code'
+# Various constants for font_style, tags_options, etc.
+css = 'dd li code.literal'
 type = 'Value'
 
 

--- a/resources/sublime-text.toml
+++ b/resources/sublime-text.toml
@@ -306,7 +306,7 @@ css = '#contexts dl.setting > dt > span.sig-name'
 type = 'Instruction'
 
 [[selectors.syntax]]
-css = '#testing ul > li > p > code:first-child'
+css = '#testing ul li > p > code:first-child'
 type = 'Test'
 
 

--- a/resources/sublime-text.toml
+++ b/resources/sublime-text.toml
@@ -223,11 +223,6 @@ type = 'Setting'
 css = 'dt#font-style dd li code'
 type = 'Value'
 
-[[selectors.color_schemes]]
-# CSS colors
-css = '#appendix-css-colors span:not(.color-block)'
-type = 'Value'
-
 
 [[selectors.themes]]
 css = 'dl.setting > dt[id]'

--- a/test/test_docset.py
+++ b/test/test_docset.py
@@ -322,6 +322,8 @@ class SublimeTextDocsetTestCase(DocsetTestCaseBase):
             ('Section', 'Scope Rules'),
             ('Setting', 'minimap_border'),
             ('Function', 'blenda() adjuster'),
+            ('Value', 'bold'),
+            ('Value', 'squiggly_underline'),
         ]
         self._test_a_doc_page_index('docs/color_schemes.html', contains)
 

--- a/test/test_docset.py
+++ b/test/test_docset.py
@@ -372,7 +372,9 @@ class SublimeTextDocsetTestCase(DocsetTestCaseBase):
             ('Instruction', 'meta_content_scope'),
             ('Test', '^'),
             ('Test', '<-'),
+            ('Test', '@'),
             ('Test', 'local-definition'),
+            ('Test', 'reindent'),
         ]
         not_contains = [
             ('Trait', '.'),

--- a/test/test_docset.py
+++ b/test/test_docset.py
@@ -322,7 +322,6 @@ class SublimeTextDocsetTestCase(DocsetTestCaseBase):
             ('Section', 'Scope Rules'),
             ('Setting', 'minimap_border'),
             ('Function', 'blenda() adjuster'),
-            ('Value', 'aliceblue'),
         ]
         self._test_a_doc_page_index('docs/color_schemes.html', contains)
 


### PR DESCRIPTION
Do not index CSS color names and fix value selector.